### PR TITLE
Implement sorting by equity-like share (#9)

### DIFF
--- a/leaderboard/algoconfig.go
+++ b/leaderboard/algoconfig.go
@@ -1,0 +1,26 @@
+package leaderboard
+
+import (
+	"fmt"
+	"time"
+)
+
+func (s *Service) getAlgorithmConfig(key string) (string, error) {
+	value, found := s.cfg.AlgorithmConfig[key]
+	if !found {
+		return "", fmt.Errorf("missing algorithmConfig: %s", key)
+	}
+	return value, nil
+}
+
+func (s *Service) getAlgorithmConfigTime(key string) (time.Time, error) {
+	valueStr, err := s.getAlgorithmConfig(key)
+	if err != nil {
+		return time.Time{}, err
+	}
+	value, err := time.Parse("2006-01-02T15:04:05Z", valueStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse datetime: %w", err)
+	}
+	return value, nil
+}

--- a/leaderboard/service.go
+++ b/leaderboard/service.go
@@ -3,7 +3,6 @@ package leaderboard
 import (
 	"fmt"
 	"net/url"
-	"strconv"
 	"sync"
 	"time"
 
@@ -16,41 +15,6 @@ import (
 	ppservice "code.vegaprotocol.io/priceproxy/service"
 	log "github.com/sirupsen/logrus"
 )
-
-// GraphQL query response structs
-
-// // Guide to the base/quote/asset vars
-// // ==================================
-// // base => BTC (for price provider)
-// // quote => USD (for price provider/calculation)
-// // vegaAsset => tDAI (for asset balance calculation only)
-
-// func (p *Party) TotalGeneral(asset string, assetPrice float64) float64 {
-// 	return p.Balance(asset, "General") * assetPrice
-// }
-
-// func (p *Party) TotalMargin(asset string, assetPrice float64) float64 {
-// 	return p.Balance(asset, "Margin") * assetPrice
-// }
-
-// func (p *Party) Total(asset string, assetPrice float64) float64 {
-// 	return p.TotalGeneral(asset, assetPrice) + p.TotalMargin(asset, assetPrice)
-// }
-
-func (p *Party) Balance(assetName string, accountType string) float64 {
-	for _, acc := range p.Accounts {
-		if acc.Asset.Symbol == assetName && acc.Type == accountType {
-			v, err := strconv.ParseFloat(acc.Balance, 64)
-			if err != nil {
-				log.WithError(err).Errorf(
-					"Failed to parse %s/%s balance [Balance]", assetName, accountType)
-				return 0
-			}
-			return v / float64(100000)
-		}
-	}
-	return 0
-}
 
 // PricingEngine is the source of price information from the price proxy.
 type PricingEngine interface {
@@ -159,6 +123,8 @@ func (s *Service) update() {
 		p, err = s.sortByPartyAccountGeneralBalance(socials)
 	case "ByPartyGovernanceVotes":
 		p, err = s.sortByPartyGovernanceVotes(socials)
+	case "ByLPEquitylikeShare":
+		p, err = s.sortByLPEquitylikeShare(socials)
 	default:
 		err = fmt.Errorf("invalid algorithm: %s", s.cfg.Algorithm)
 	}

--- a/leaderboard/sort_by_governance_votes-sample-config.yaml
+++ b/leaderboard/sort_by_governance_votes-sample-config.yaml
@@ -1,0 +1,12 @@
+---
+algorithm: ByPartyGovernanceVotes
+
+algorithmConfig:
+  since: "2020-12-31T23:45:56Z"
+
+defaultDisplay: Vote Count
+
+defaultSort: Vote Count
+
+headers:
+  - Vote Count

--- a/leaderboard/sort_by_governance_votes.go
+++ b/leaderboard/sort_by_governance_votes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -19,13 +18,9 @@ func (s *Service) sortByPartyGovernanceVotes(socials map[string]string) ([]Parti
 
 	sParties := socialParties(socials, parties)
 	participants := []Participant{}
-	sinceStr, found := s.cfg.AlgorithmConfig["since"]
-	if !found {
-		return nil, fmt.Errorf("missing algorithmConfig: since")
-	}
-	since, err := time.Parse("2006-01-02T15:04:05Z", sinceStr)
-	if !found {
-		return nil, fmt.Errorf("failed to parse datetime: %w", err)
+	since, err := s.getAlgorithmConfigTime("since")
+	if err != nil {
+		return nil, err
 	}
 	log.WithFields(log.Fields{"since ": since.String()}).Info("Algo cfg")
 	for _, party := range sParties {

--- a/leaderboard/sort_by_lp_equitylike_share-sample-config.yaml
+++ b/leaderboard/sort_by_lp_equitylike_share-sample-config.yaml
@@ -1,0 +1,16 @@
+---
+algorithm: ByLPEquitylikeShare
+
+algorithmConfig:
+  marketID: your_market_ID_here
+  since: "2020-12-31T23:45:56Z"
+
+defaultDisplay: Equity-like Share
+
+defaultSort: Equity-like Share
+
+headers:
+  - Commitment Amount
+  - Average Entry Valuation
+  - Equity-like Share
+  - Fee

--- a/leaderboard/sort_by_lp_equitylike_share.go
+++ b/leaderboard/sort_by_lp_equitylike_share.go
@@ -1,0 +1,171 @@
+package leaderboard
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/machinebox/graphql"
+	log "github.com/sirupsen/logrus"
+)
+
+type PartyJustID struct {
+	ID string `json:"id"`
+}
+
+type LiquidityProvision struct {
+	CreatedAt        time.Time   `json:"createdAt"`
+	CommitmentAmount int         `json:"commitmentAmount"`
+	Fee              string      `json:"fee"` // float
+	Status           string      `json:"status"`
+	Party            PartyJustID `json:"party"`
+}
+
+type LiquidityProviderFeeShare struct {
+	AverageEntryValuation string      `json:"averageEntryValuation"` // uint64 ** 10^DP
+	EquityLikeShare       string      `json:"equityLikeShare"`       // float
+	Party                 PartyJustID `json:"party"`
+}
+
+type MarketData struct {
+	LPFeeShare []LiquidityProviderFeeShare `json:"liquidityProviderFeeShare"`
+}
+
+type Market struct {
+	LiquidityProvisions []LiquidityProvision `json:"liquidityProvisions"`
+	Data                MarketData           `json:"data"`
+}
+
+type marketResponse struct {
+	Market Market `json:"market"`
+}
+
+func (s *Service) sortByLPEquitylikeShare(socials map[string]string) ([]Participant, error) {
+
+	marketID, err := s.getAlgorithmConfig("marketID")
+	if err != nil {
+		return nil, err
+	}
+	since, err := s.getAlgorithmConfigTime("since")
+	if err != nil {
+		return nil, err
+	}
+
+	gqlQuery := `query ($marketID: ID!) {
+		market(id:$marketID) {
+			liquidityProvisions {
+				createdAt
+				commitmentAmount
+				fee
+				status
+				party {
+					id
+				}
+			}
+			data {
+				liquidityProviderFeeShare {
+					averageEntryValuation
+					equityLikeShare
+					party {
+						id
+					}
+				}
+			}
+		}
+	}`
+	client := graphql.NewClient(s.cfg.VegaGraphQLURL.String())
+	req := graphql.NewRequest(gqlQuery)
+	req.Var("marketID", marketID)
+	req.Header.Set("Cache-Control", "no-cache")
+
+	commitmentAmount := make(map[string]int)
+	averageEntryValuation := make(map[string]float64)
+	equitylikeShare := make(map[string]float64)
+	fee := make(map[string]float64)
+
+	var response marketResponse
+	ctx := context.Background()
+	if err = client.Run(ctx, req, &response); err != nil {
+		return nil, fmt.Errorf("failed to get market liquidity provider info: %w", err)
+	}
+	for i, lp := range response.Market.LiquidityProvisions {
+		if lp.Status != "Active" {
+			continue
+		}
+		if !lp.CreatedAt.After(since) {
+			continue
+		}
+
+		log.WithFields(log.Fields{
+			"i":                i,
+			"createdAt":        lp.CreatedAt,
+			"commitmentAmount": lp.CommitmentAmount,
+			"fee":              lp.Fee,
+			"party":            lp.Party.ID,
+		}).Debug("Liquidity provision")
+		commitmentAmount[lp.Party.ID] = lp.CommitmentAmount
+		fee[lp.Party.ID], err = strconv.ParseFloat(lp.Fee, 64)
+		if err != nil {
+			fee[lp.Party.ID] = -5.0
+		}
+	}
+	for i, lpfs := range response.Market.Data.LPFeeShare {
+		log.WithFields(log.Fields{
+			"i":                     i,
+			"averageEntryValuation": lpfs.AverageEntryValuation,
+			"equityLikeShare":       lpfs.EquityLikeShare,
+			"party":                 lpfs.Party.ID,
+		}).Debug("Liquidity provision fee share")
+		averageEntryValuation[lpfs.Party.ID], err = strconv.ParseFloat(lpfs.AverageEntryValuation, 64)
+		if err != nil {
+			averageEntryValuation[lpfs.Party.ID] = -6.0
+		}
+		equitylikeShare[lpfs.Party.ID], err = strconv.ParseFloat(lpfs.EquityLikeShare, 64)
+		if err != nil {
+			equitylikeShare[lpfs.Party.ID] = -7.0
+		}
+	}
+
+	parties := make([]Party, 0)
+	sParties := socialParties(socials, parties)
+	participants := []Participant{}
+	for _, party := range sParties {
+		ca, found := commitmentAmount[party.ID]
+		if !found {
+			ca = 0
+		}
+		aev, found := averageEntryValuation[party.ID]
+		if !found {
+			aev = 0.0
+		}
+		els, found := equitylikeShare[party.ID]
+		if !found {
+			els = 0.0
+		}
+		f := fee[party.ID]
+		if !found {
+			f = 0.0
+		}
+
+		participants = append(participants, Participant{
+			PublicKey:     party.ID,
+			TwitterHandle: party.social,
+			Data: []string{
+				fmt.Sprintf("%d", ca/10000),      // TODO: market decimal places
+				fmt.Sprintf("%.5f", aev/10000.0), // TODO: market decimal places
+				fmt.Sprintf("%.6f%%", els*100.0),
+				fmt.Sprintf("%.6f%%", f*100.0),
+			},
+			sortNum: els,
+		})
+	}
+
+	sortFunc := func(i, j int) bool {
+		return participants[i].sortNum > participants[j].sortNum
+	}
+	sort.Slice(participants, sortFunc)
+
+	return participants, nil
+}

--- a/leaderboard/sort_by_party_account_general_balance-sampleconfig.yaml
+++ b/leaderboard/sort_by_party_account_general_balance-sampleconfig.yaml
@@ -1,0 +1,11 @@
+---
+algorithm: ByPartyAccountGeneralBalance
+
+algorithmConfig: {}
+
+defaultDisplay: Balance
+
+defaultSort: Balance
+
+headers:
+  - Balance

--- a/leaderboard/sort_by_party_account_general_balance.go
+++ b/leaderboard/sort_by_party_account_general_balance.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (s *Service) sortByPartyAccountGeneralBalance(socials map[string]string) ([]Participant, error) {
-	// Load all parties with accounts from GraphQL end-point
 	gqlQuery := "query {parties {id accounts {type balance asset {symbol}}}}"
 	ctx := context.Background()
 	parties, err := getParties(ctx, s.cfg.VegaGraphQLURL.String(), gqlQuery)

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 	// Run our server in a goroutine so that it doesn't block.
 	go func() {
 		svc.Start()
-		if err := srv.ListenAndServe(); err != nil {
+		if err := srv.ListenAndServe(); err != nil && err.Error() != "http: Server closed" {
 			log.WithError(err).Warn("Failed to serve")
 		}
 	}()

--- a/server.go
+++ b/server.go
@@ -1,3 +1,0 @@
-package main
-
-func startServer() {}


### PR DESCRIPTION
This PR implements sorting by equity-like share.

## Config
```yaml
algorithm: ByLPEquitylikeShare

algorithmConfig:
  marketID: your_market_ID_here
  since: "2020-12-31T23:45:56Z"

defaultDisplay: Equity-like Share

defaultSort: Equity-like Share

headers:
  - Commitment Amount
  - Average Entry Valuation
  - Equity-like Share
  - Fee
```

## Output
```json5
{
  "participants": [
    {
      "publicKey": "a1b2...",
      "twitterHandle": "twitterer",
      "data": [
        "650000",
        "112821260823.80533",
        "0.000142%",
        "50.000000%"
      ]
    },
    // ...
  ]
}
```


Closes #9.