### PR TITLE
load only 1 trades from the market per party

### DIFF
--- a/leaderboard/sort_by_party_account_general_balance.go
+++ b/leaderboard/sort_by_party_account_general_balance.go
@@ -10,10 +10,10 @@ import (
 )
 
 func (s *Service) sortByPartyAccountGeneralBalance(socials map[string]string) ([]Participant, error) {
-	marketID, err := s.getAlgorithmConfig("marketID")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get algorithm config: %w", err)
-	}
+	// marketID, err := s.getAlgorithmConfig("marketID")
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to get algorithm config: %w", err)
+	// }
 
 	gqlQueryPartiesAccounts := `query($assetId: String!) {
 		parties {
@@ -27,14 +27,14 @@ func (s *Service) sortByPartyAccountGeneralBalance(socials map[string]string) ([
 			}
 		}
 	}`
-	gqlQueryPartiesTrades := `query($marketId: ID!, $partyId: ID!) {
-		parties(id: $partyId) {
-			trades(marketId: $marketId, first: 1, last: 2) {
-				id
-				createdAt
-			}
-		}
-	}`
+	// gqlQueryPartiesTrades := `query($marketId: ID!, $partyId: ID!) {
+	// 	parties(id: $partyId) {
+	// 		trades(marketId: $marketId, first: 1, last: 2) {
+	// 			id
+	// 			createdAt
+	// 		}
+	// 	}
+	// }`
 
 	ctx := context.Background()
 	parties, err := getParties(
@@ -55,24 +55,24 @@ func (s *Service) sortByPartyAccountGeneralBalance(socials map[string]string) ([
 	for _, party := range sParties {
 		// Add trades for each party, one by one, to avoid GraphQL query timeouts.
 		log.WithFields(log.Fields{"partyID": party.ID}).Debug("Getting trades for party")
-		partyTrades, err := getParties(
-			ctx,
-			s.cfg.VegaGraphQLURL.String(),
-			gqlQueryPartiesTrades,
-			map[string]string{
-				"marketId": marketID,
-				"partyId":  party.ID,
-			},
-			nil,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get list of trades for parties: %w", err)
-		}
-		if len(partyTrades) == 1 {
-			// Party exists on Vega
-			party.Trades = partyTrades[0].Trades
-		}
-		log.WithFields(log.Fields{"partyID": party.ID, "trades": len(party.Trades)}).Debug("Got trades for party")
+		// partyTrades, err := getParties(
+		// 	ctx,
+		// 	s.cfg.VegaGraphQLURL.String(),
+		// 	gqlQueryPartiesTrades,
+		// 	map[string]string{
+		// 		"marketId": marketID,
+		// 		"partyId":  party.ID,
+		// 	},
+		// 	nil,
+		// )
+		// if err != nil {
+		// 	return nil, fmt.Errorf("failed to get list of trades for parties: %w", err)
+		// }
+		// if len(partyTrades) == 1 {
+		// 	// Party exists on Vega
+		// 	party.Trades = partyTrades[0].Trades
+		// }
+		// log.WithFields(log.Fields{"partyID": party.ID, "trades": len(party.Trades)}).Debug("Got trades for party")
 
 		// Count only trades that happened during the competition.
 		// tradeCount := 0
@@ -84,16 +84,16 @@ func (s *Service) sortByPartyAccountGeneralBalance(socials map[string]string) ([
 
 		balanceGeneral := party.Balance(s.cfg.VegaAsset, "General", "Margin")
 		var sortNum float64
-		var balanceGeneralStr string
+		// var balanceGeneralStr string
 		// if tradeCount > 0 {
-		if len(party.Trades) > 0 {
-			balanceGeneralStr = strconv.FormatFloat(balanceGeneral, 'f', 5, 32)
-			sortNum = balanceGeneral
-		} else {
-			// Untraded folks have not participated in the competition.
-			balanceGeneralStr = "n/a"
-			sortNum = -1.0e20
-		}
+		// if len(party.Trades) > 0 {
+		balanceGeneralStr := strconv.FormatFloat(balanceGeneral, 'f', 5, 32)
+		sortNum = balanceGeneral
+		// } else {
+		// 	// Untraded folks have not participated in the competition.
+		// 	balanceGeneralStr = "n/a"
+		// 	sortNum = -1.0e20
+		// }
 		participants = append(participants, Participant{
 			PublicKey:     party.ID,
 			TwitterHandle: party.social,


### PR DESCRIPTION
We now load only 1 trade per party per market in order to reduce slighlty pressure on the API (using graphql this means that for each trade we unmarshal proto from store, then marshal proto to send via grpc, then unmarshal proto again, to then marshal json and do reflection on every single fields in graphql).

So if some parties had 100+ trades, that would put quite some pressure on the core.