### PR TITLE
Add social registration only leaderboard (for confirming that a user has been added to verified list)

### DIFF
--- a/leaderboard/service.go
+++ b/leaderboard/service.go
@@ -215,6 +215,8 @@ func (s *Service) update() {
 		p, err = s.sortByPartyGovernanceVotes(socials)
 	case "ByLPEquitylikeShare":
 		p, err = s.sortByLPEquitylikeShare(socials)
+	case "BySocialRegistration":
+		p, err = s.sortBySocialRegistration(s.verifier.List())
 	default:
 		err = fmt.Errorf("invalid algorithm: %s", s.cfg.Algorithm)
 	}

--- a/leaderboard/sort_by_social_registration-sample-config.yaml
+++ b/leaderboard/sort_by_social_registration-sample-config.yaml
@@ -1,0 +1,11 @@
+---
+algorithm: BySocialRegistration
+
+algorithmConfig: {}
+
+defaultDisplay: Registered
+
+defaultSort: Registered
+
+headers:
+  - Registered

--- a/leaderboard/sort_by_social_registration.go
+++ b/leaderboard/sort_by_social_registration.go
@@ -1,0 +1,32 @@
+package leaderboard
+
+import (
+	"sort"
+
+	"github.com/vegaprotocol/topgun-service/verifier"
+)
+
+func (s *Service) sortBySocialRegistration(socials *verifier.Socials) ([]Participant, error) {
+
+	// A leaderboard to show only registered social accounts, used to verify that they have
+	// registered successfully with the twitter service/vega incentives
+
+	count := 0
+	participants := []Participant{}
+	for _, s := range *socials {
+		count++
+		participants = append(participants, Participant{
+			PublicKey:     s.PartyID,
+			TwitterHandle: s.TwitterHandle,
+			Data:          []string{ "Registered" },
+			sortNum:       float64(count),
+		})
+	}
+
+	sortFunc := func(i, j int) bool {
+		return participants[i].sortNum > participants[j].sortNum
+	}
+	sort.Slice(participants, sortFunc)
+
+	return participants, nil
+}

--- a/verifier/service.go
+++ b/verifier/service.go
@@ -15,6 +15,8 @@ import (
 type Socials []struct {
 	PartyID       string `json:"party_id"`
 	TwitterHandle string `json:"twitter_handle"`
+	CreatedAt     int64 `json:"created"`
+	UpdatedAt     int64 `json:"last_modified"`
 }
 
 type Service struct {


### PR DESCRIPTION
Closes #39 

- We need a perpetual leaderboard/list that will show if a user has verified successfully via Twitter / socials.
- This PR adds the functionality to run a leaderboard with a list of twitter usernames, latest added descending